### PR TITLE
chore: install and configure Zod for API data validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^5.1.0",
-        "morgan": "^1.10.0"
+        "morgan": "^1.10.0",
+        "zod": "^4.0.5"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -1780,6 +1781,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
+      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "zod": "^4.0.5"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES6",                           // Use modern JavaScript features
-    "module": "CommonJS",                      // Required for Node.js compatibility
+    "module": "node16",                      // Required for Node.js compatibility
+    "moduleResolution": "node16",          // Use Node.js module resolution strategy
     "rootDir": "./src",                        // Your TypeScript source files
     "outDir": "./dist",                        // Compiled JavaScript output
     "esModuleInterop": true,                   // Allows default import syntax for CommonJS modules like Express


### PR DESCRIPTION
This branch adds Zod for schema-based validation of API request data.

- Installed zod as a dependency
- Configured TypeScript (tsconfig.json) to support subpath imports if needed