### PR TITLE
Add Category model using Sequelize and TypeScript

### DIFF
--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -1,0 +1,60 @@
+import { Model, DataTypes, Sequelize } from "sequelize";
+
+export interface CategoryAttributes {
+  id?: string;
+  name: string;
+  description?: string;
+  status?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export class Category extends Model<CategoryAttributes> implements CategoryAttributes {
+  public id!: string;
+  public name!: string;
+  public description?: string;
+  public status?: string;
+
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+}
+
+export function initCategoryModel(sequelize: Sequelize) {
+  Category.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      description: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      status: {
+        type: DataTypes.STRING,
+        defaultValue: "active",
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      sequelize,
+      modelName: "Category",
+      tableName: "categories", 
+    }
+  );
+  return Category;
+}


### PR DESCRIPTION
This PR adds a new Category model to the project with Sequelize and TypeScript. 

Key details include:
```

1. The model uses UUIDs as primary keys for unique identification.
2 . It defines essential fields: name (required),  description, and status with a default of "active".

3. Includes timestamps createdAt and updatedAt with default values set to the current time.
 
4. The model is initialized via initCategoryModel to integrate with the Sequelize instance.

5.  Table name is explicitly set to "categories" for clarity and consistency.
```